### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Run audit check
-      uses: actions-rs/audit-check@v1
+      uses: rustsec/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
-      - name: Run cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
       - name: Run cargo publish
-        run: cargo publish
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -25,21 +25,18 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
   clippy_check:
     name: Clippy check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
-      - uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -47,19 +44,19 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install clippy
-        run: rustup component add clippy
-      - name: Run clippy check
-        uses: actions-rs/clippy-check@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          components: clippy
+      - name: Run clippy check
+        run: cargo clippy --all-features
+
   test:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -67,11 +64,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
   publish_on_crates_io:
     name: Publish on crates.io
     runs-on: ubuntu-latest
@@ -82,15 +77,10 @@ jobs:
       - test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo login
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
       - name: Run cargo publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
+        run: cargo publish


### PR DESCRIPTION
Hi. I want to help to actualize the library, it will be a Pull Request series. It's worth starting with CI actualization.

- update [actions/checkout](https://github.com/actions/checkout) to v4
- replace unmaintained [actions-rs/cargo](https://github.com/actions-rs/cargo) with using cargo directly
- replace unmaintained [actions-rs/clippy-check](https://github.com/actions-rs/clippy-check) with using cargo clippy directly
- replace unmaintained [actions-rs/audit-check](https://github.com/actions-rs/audit-check) by [rustsec/audit-check](https://github.com/rustsec/audit-check) (also unmaintained, but much newer)
- replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) [actions-rs/toolchain](https://github.com/actions-rs/toolchain) by [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain)

> Node 16 has reached its end of life, prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/