### PR TITLE
Leave only the necessary features in chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["now"] }
 thiserror = "1.0"
 pnet = "0.33"
 


### PR DESCRIPTION
Currently `chrono` pulls a lot of dependencies to just get the current system time. Currently this module does not support wasm, there is no need to know other timezone than UTC. In total this change removes 26 dependencies. If needed, I think flags can be added in the future, but so far no one has asked 🤷‍♂️