### PR TITLE
Use pnet datalink directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 chrono = "0.4"
 thiserror = "1.0"
-pnet_datalink = "0.34"
+pnet_datalink = { version = "0.34", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 chrono = "0.4"
 thiserror = "1.0"
-pnet_datalink = { version = "0.34", default-features = false }
+pnet_datalink = { version = "0.35", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 chrono = "0.4"
 thiserror = "1.0"
-pnet = "0.33"
+pnet_datalink = "0.34"
 
 [dev-dependencies]
 bencher = "0.1"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,4 @@
 use chrono::prelude::*;
-use pnet::datalink;
 use std::{
     net::{IpAddr, Ipv4Addr},
     sync::{Arc, Mutex},
@@ -100,7 +99,7 @@ impl<'a> Builder<'a> {
 }
 
 fn private_ipv4() -> Option<Ipv4Addr> {
-    datalink::interfaces()
+    pnet_datalink::interfaces()
         .iter()
         .filter(|interface| interface.is_up() && !interface.is_loopback())
         .map(|interface| {


### PR DESCRIPTION
Looking at my `Cargo.lock` I found a significant number of packages that `pnet` pulls, although only one standalone module is needed. This will also get rid of the syn v1 dependency. And I also simplified the code of the `private_ipv4` function 😅